### PR TITLE
fix plugins

### DIFF
--- a/Assets/WebGLNativeInputField/Plugins/WebGL/WebNativeDialog.jslib
+++ b/Assets/WebGLNativeInputField/Plugins/WebGL/WebNativeDialog.jslib
@@ -1,20 +1,21 @@
 ﻿var WebNativeDialog = {
   NativeDialogPrompt:function (title , defaultValue){
-    defaultValue = Pointer_stringify(defaultValue);
-    title = Pointer_stringify(title);
+    defaultValue = UTF8ToString(defaultValue);
+    title = UTF8ToString(title);
     var result = window.prompt( title , defaultValue );
     if( !result ){
       result = defaultValue;
     }
-    var buffer = _malloc(lengthBytesUTF8(result) + 1);
-    writeStringToMemory(result, buffer);
+    var bufferSize = lengthBytesUTF8(result) + 1;
+    var buffer = _malloc(bufferSize);
+    stringToUTF8(result, buffer, bufferSize);
     return buffer;
   },
   SetupOverlayDialogHtml:function(title,defaultValue,okBtnText,cancelBtnText){
-    title = Pointer_stringify(title);
-    defaultValue = Pointer_stringify(defaultValue);
-    okBtnText = Pointer_stringify(okBtnText);
-    cancelBtnText = Pointer_stringify(cancelBtnText);
+    title = UTF8ToString(title);
+    defaultValue = UTF8ToString(defaultValue);
+    okBtnText = UTF8ToString(okBtnText);
+    cancelBtnText = UTF8ToString(cancelBtnText);
 
     if( !document.getElementById("nativeInputDialogInput" ) ){
       // setup css
@@ -69,7 +70,7 @@
     document.getElementById("nativeInputDialog" ).style.display = "";
   },
   HideUnityScreenIfHtmlOverlayCant:function(){
-    if( navigator.userAgent.indexOf("Chrome/") < 0 ){
+    if( navigator.userAgent.indexOf("Chrome") < 0 && navigator.userAgent.indexOf("Firefox") < 0 ){
       document.getElementById("canvas").style.display="none";
     }
   },
@@ -97,8 +98,9 @@
     if( inputField && inputField.value ){
       result = inputField.value;
     }
-    var buffer = _malloc(lengthBytesUTF8(result) + 1);
-    writeStringToMemory(result, buffer);
+    var bufferSize = lengthBytesUTF8(result) + 1;
+    var buffer = _malloc(bufferSize);
+    stringToUTF8(result, buffer, bufferSize);
     return buffer;
   }
 


### PR DESCRIPTION
## 概要
`WebNativeDialog.jslib` を修正しました。
Unity2023.2.12では画像のように、 `Pointer_stringify` でエラーが出ます。
![エラーの様子](https://github.com/unity3d-jp/WebGLNativeInputField/assets/39724986/be5a99b7-02fe-4500-843c-0cb9c234314d)
画像は無いですが、 `writeStringToMemory` でもエラーが出ます。
なので、これを修正しました。

## 修正内容
- `Pointer_stringify` を `UTF8ToString` に変えました。
- `writeStringToMemory` を `stringToUTF8` に変え、第三引数にbufferSizeを渡すようにしました。

参考：https://docs.unity3d.com/ja/2023.2/Manual/webgl-interactingwithbrowserscripting.html

## 動作確認
自作ゲームですが、こちらで確認できます。
タイトル画面左下の「セーブ管理」、ゲーム開始直後の名前入力の場面でWebGLNativeInputFieldを使用しています。

### 修正後
https://unityroom.com/games/thsuijin
問題無く文字列入力を出来ると思います。

### 修正前
https://beta.unityroom.com/games/thsuijin
文字列入力の場面でエラーが出てゲームがフリーズします。